### PR TITLE
Add `SystemShutdown`

### DIFF
--- a/contracts/Interfaces/ICommunityIssuance.sol
+++ b/contracts/Interfaces/ICommunityIssuance.sol
@@ -12,9 +12,13 @@ interface ICommunityIssuance {
 
     // --- Functions ---
 
+    function setPaused(bool _isPaused) external;
+
+    function shutdownAdmin() external view returns (address);
+
     function LQTYSupplyCap() external view returns (uint);
 
-    function setAddresses(address _lqtyTokenAddress, address _stabilityPoolAddress, address _lqtyTreasuryAddress) external;
+    function setAddresses(address _lqtyTokenAddress, address _stabilityPoolAddress, address _lqtyTreasuryAddress, address _shutdownAdminAddress) external;
 
     function issueLQTY() external returns (uint);
 

--- a/contracts/Interfaces/ILUSDToken.sol
+++ b/contracts/Interfaces/ILUSDToken.sol
@@ -5,8 +5,8 @@ pragma solidity 0.6.11;
 import "../Dependencies/IERC20.sol";
 import "../Dependencies/IERC2612.sol";
 
-interface ILUSDToken is IERC20, IERC2612 { 
-    
+interface ILUSDToken is IERC20, IERC2612 {
+
     // --- Events ---
 
     event TroveManagerAddressChanged(address _troveManagerAddress);
@@ -16,6 +16,10 @@ interface ILUSDToken is IERC20, IERC2612 {
     event LUSDTokenBalanceUpdated(address _user, uint _amount);
 
     // --- Functions ---
+
+    function setPaused(bool _isPaused) external;
+
+    function shutdownAdmin() external view returns (address);
 
     function mint(address _account, uint256 _amount) external;
 

--- a/contracts/SystemShutdown.sol
+++ b/contracts/SystemShutdown.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+import "./Dependencies/Ownable.sol";
+import "./Interfaces/ICommunityIssuance.sol";
+import "./Interfaces/ILUSDToken.sol";
+
+contract SystemShutdown is Ownable {
+
+    struct Contracts {
+        ILUSDToken synth;
+        ICommunityIssuance issuer;
+    }
+
+    Contracts[] public registeredContracts;
+
+    event ContractsRegistered(
+        ILUSDToken synth,
+        ICommunityIssuance issuer,
+        uint id
+    );
+
+    function registerContracts(ILUSDToken _synth, ICommunityIssuance _issuer) external onlyOwner {
+        require(_synth.shutdownAdmin() == address(this));
+        require(_issuer.shutdownAdmin() == address(this));
+        registeredContracts.push(Contracts({synth: _synth, issuer: _issuer}));
+        emit ContractsRegistered(_synth, _issuer, registeredContracts.length - 1);
+    }
+
+    function pause(uint _id) external onlyOwner {
+        registeredContracts[_id].synth.setPaused(true);
+        registeredContracts[_id].issuer.setPaused(true);
+    }
+
+    function unpause(uint _id) external onlyOwner {
+        registeredContracts[_id].synth.setPaused(false);
+        registeredContracts[_id].issuer.setPaused(false);
+    }
+
+}

--- a/contracts/TestContracts/LUSDTokenTester.sol
+++ b/contracts/TestContracts/LUSDTokenTester.sol
@@ -14,13 +14,15 @@ contract LUSDTokenTester is LUSDToken {
         address _troveManagerAddress,
         address _stabilityPoolAddress,
         address _borrowerOperationsAddress,
-        address _flashLenderAddress
+        address _flashLenderAddress,
+        address _shutdownAdminAddress
     ) public LUSDToken(_name,
                       _symbol,
                       _troveManagerAddress,
                       _stabilityPoolAddress,
                       _borrowerOperationsAddress,
-                      _flashLenderAddress) {}
+                      _flashLenderAddress,
+                      _shutdownAdminAddress) {}
 
     function unprotectedMint(address _account, uint256 _amount) external {
         // No check on caller here

--- a/test/CollSurplusPool.js
+++ b/test/CollSurplusPool.js
@@ -38,7 +38,8 @@ contract('CollSurplusPool', async accounts => {
       contracts.troveManager.address,
       contracts.stabilityPool.address,
       contracts.borrowerOperations.address,
-      contracts.flashLender.address
+      contracts.flashLender.address,
+      contracts.systemShutdown.address,
     )
     const LQTYContracts = await deploymentHelper.deployLQTYContracts(bountyAddress, lpRewardsAddress, multisig)
 

--- a/test/GasCompensationTest.js
+++ b/test/GasCompensationTest.js
@@ -58,7 +58,8 @@ contract('Gas compensation tests', async accounts => {
       contracts.troveManager.address,
       contracts.stabilityPool.address,
       contracts.borrowerOperations.address,
-      contracts.flashLender.address
+      contracts.flashLender.address,
+      contracts.systemShutdown.address,
     )
     const LQTYContracts = await deploymentHelper.deployLQTYContracts(bountyAddress, lpRewardsAddress, multisig)
 

--- a/test/HintHelpers_getApproxHintTest.js
+++ b/test/HintHelpers_getApproxHintTest.js
@@ -81,7 +81,8 @@ contract('HintHelpers', async accounts => {
       contracts.troveManager.address,
       contracts.stabilityPool.address,
       contracts.borrowerOperations.address,
-      contracts.flashLender.address
+      contracts.flashLender.address,
+      contracts.systemShutdown.address,
     )
     const LQTYContracts = await deploymentHelper.deployLQTYContracts(bountyAddress, lpRewardsAddress, multisig)
 

--- a/test/StabilityPoolTest.js
+++ b/test/StabilityPoolTest.js
@@ -67,7 +67,8 @@ contract('StabilityPool', async accounts => {
         contracts.troveManager.address,
         contracts.stabilityPool.address,
         contracts.borrowerOperations.address,
-        contracts.flashLender.address
+        contracts.flashLender.address,
+        contracts.systemShutdown.address,
       )
       priceFeed = contracts.priceFeedTestnet
       lusdToken = contracts.lusdToken

--- a/test/StabilityPool_LQTYIssuanceTest.js
+++ b/test/StabilityPool_LQTYIssuanceTest.js
@@ -58,7 +58,8 @@ contract('StabilityPool - LQTY Rewards', async accounts => {
         contracts.troveManager.address,
         contracts.stabilityPool.address,
         contracts.borrowerOperations.address,
-        contracts.flashLender.address
+        contracts.flashLender.address,
+        contracts.systemShutdown.address,
       )
       // this adds too much time to the process and as a result tests fail.
       // to make this work this needs to run before the deployment below.

--- a/test/TroveManagerTest.js
+++ b/test/TroveManagerTest.js
@@ -61,7 +61,8 @@ contract('TroveManager', async accounts => {
       contracts.troveManager.address,
       contracts.stabilityPool.address,
       contracts.borrowerOperations.address,
-      contracts.flashLender.address
+      contracts.flashLender.address,
+      contracts.systemShutdown.address
     )
     const LQTYContracts = await deploymentHelper.deployLQTYContracts(bountyAddress, lpRewardsAddress, multisig)
     priceFeed = contracts.priceFeedTestnet

--- a/test/TroveManager_LiquidationRewardsTest.js
+++ b/test/TroveManager_LiquidationRewardsTest.js
@@ -46,7 +46,8 @@ contract('TroveManager - Redistribution reward calculations', async accounts => 
       contracts.troveManager.address,
       contracts.stabilityPool.address,
       contracts.borrowerOperations.address,
-      contracts.flashLender.address
+      contracts.flashLender.address,
+      contracts.systemShutdown.address,
     )
     const LQTYContracts = await deploymentHelper.deployLQTYContracts(bountyAddress, lpRewardsAddress, multisig)
 

--- a/test/TroveManager_RecoveryModeTest.js
+++ b/test/TroveManager_RecoveryModeTest.js
@@ -62,7 +62,8 @@ contract('TroveManager - in Recovery Mode', async accounts => {
       contracts.troveManager.address,
       contracts.stabilityPool.address,
       contracts.borrowerOperations.address,
-      contracts.flashLender.address
+      contracts.flashLender.address,
+      contracts.systemShutdown.address,
     )
     const LQTYContracts = await deploymentHelper.deployLQTYContracts(bountyAddress, lpRewardsAddress, multisig)
 

--- a/test/stakeDeclineTest.js
+++ b/test/stakeDeclineTest.js
@@ -63,7 +63,8 @@ contract('TroveManager', async accounts => {
       contracts.troveManager.address,
       contracts.stabilityPool.address,
       contracts.borrowerOperations.address,
-      contracts.flashLender.address
+      contracts.flashLender.address,
+      contracts.systemShutdown.address,
     )
     const LQTYContracts = await deploymentHelper.deployLQTYContracts(bountyAddress, lpRewardsAddress, multisig)
 

--- a/utils/deploymentHelpers.js
+++ b/utils/deploymentHelpers.js
@@ -11,6 +11,7 @@ const FunctionCaller = artifacts.require("./TestContracts/FunctionCaller.sol")
 const BorrowerOperations = artifacts.require("./BorrowerOperations.sol")
 const HintHelpers = artifacts.require("./HintHelpers.sol")
 const FlashLender = artifacts.require("./FlashLender.sol")
+const SystemShutdown = artifacts.require("./SystemShutdown.sol")
 
 const LQTYStaking = artifacts.require("./MultiRewards.sol")
 const LQTYToken = artifacts.require("./LQTYToken.sol")
@@ -79,13 +80,15 @@ class DeploymentHelper {
     const borrowerOperations = await BorrowerOperations.new()
     const hintHelpers = await HintHelpers.new()
     const flashLender = await FlashLender.new()
+    const systemShutdown = await SystemShutdown.new()
     const lusdToken = await LUSDToken.new(
       "LUSD Stablecoin",
       "LUSD",
       troveManager.address,
       stabilityPool.address,
       borrowerOperations.address,
-      flashLender.address
+      flashLender.address,
+      systemShutdown.address
     )
     const collateral = await MockCollateral.new("Collateral", "CLT")
 
@@ -103,6 +106,7 @@ class DeploymentHelper {
     HintHelpers.setAsDeployed(hintHelpers)
     MockCollateral.setAsDeployed(collateral)
     FlashLender.setAsDeployed(flashLender)
+    SystemShutdown.setAsDeployed(systemShutdown)
 
     const coreContracts = {
       priceFeedTestnet,
@@ -118,7 +122,8 @@ class DeploymentHelper {
       borrowerOperations,
       hintHelpers,
       collateral,
-      flashLender
+      flashLender,
+      systemShutdown
     }
     return coreContracts
   }
@@ -129,6 +134,7 @@ class DeploymentHelper {
     // Contract without testers (yet)
     testerContracts.priceFeedTestnet = await PriceFeedTestnet.new()
     testerContracts.sortedTroves = await SortedTroves.new()
+    testerContracts.systemShutdown = await SystemShutdown.new()
     // Actual tester contracts
     testerContracts.communityIssuance = await CommunityIssuanceTester.new("32000000000000000000000000", "999998681227695000")
     testerContracts.activePool = await ActivePoolTester.new()
@@ -149,6 +155,7 @@ class DeploymentHelper {
       testerContracts.stabilityPool.address,
       testerContracts.borrowerOperations.address,
       testerContracts.flashLender.address,
+      testerContracts.systemShutdown.address,
     )
     testerContracts.collateral = await MockCollateral.new("Collateral", "CLT")
     return testerContracts
@@ -265,7 +272,8 @@ class DeploymentHelper {
       contracts.troveManager.address,
       contracts.stabilityPool.address,
       contracts.borrowerOperations.address,
-      contracts.flashLender.address
+      contracts.flashLender.address,
+      contracts.systemShutdown.address,
     )
     return contracts
   }
@@ -277,7 +285,8 @@ class DeploymentHelper {
       contracts.troveManager.address,
       contracts.stabilityPool.address,
       contracts.borrowerOperations.address,
-      contracts.flashLender.address
+      contracts.flashLender.address,
+      contracts.systemShutdown.address,
     )
     return contracts
   }
@@ -384,7 +393,8 @@ class DeploymentHelper {
     await LQTYContracts.communityIssuance.setAddresses(
       LQTYContracts.lqtyToken.address,
       coreContracts.stabilityPool.address,
-      LQTYContracts.lqtyTreasury.address
+      LQTYContracts.lqtyTreasury.address,
+      coreContracts.systemShutdown.address,
     )
   }
 


### PR DESCRIPTION
Adds the `SystemShutdown` contract, which allows pausing and unpausing the system by:

1. preventing the minting of LUSD
2. forcing LQTY emissions to 0

This is useful because we plan to operate with multiple versions of the system active at once, and some may have less reliable collaterals than others.  In case of a black swan event in one system, we can pause to prevent collateral damage to the other instances.